### PR TITLE
use string.match instead of lpeg

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -7,7 +7,7 @@ local backspace = function(tabwidth)
     if sel.pos ~= nil and sel.pos ~= 0 then
       local pos, col = sel.pos, sel.col
       local delete, move = 1, 1
-      local start = vis.lpeg.match(vis.lpeg.P(' ') ^ 1, file.lines[sel.line])
+      local start = string.match(file.lines[sel.line], '^ +()')
       if
           (vis.win.options == nil or vis.win.options.expandtab)
           and start ~= nil


### PR DESCRIPTION
Basically, lpeg.match is just anchored and returns the position, so a "^ +()" can mimic it (I think), vis can work without lpeg. so maybe this makes it more portable?

I'm unsure if this will work or if its even useful.